### PR TITLE
feat: support more output formats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,6 +93,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ascii_table"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c2bee9b9ee0e5768772e38c07ef0ba23a490d7e1336ec7207c25712a2661c55"
+
+[[package]]
 name = "async-trait"
 version = "0.1.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -561,8 +567,9 @@ dependencies = [
 
 [[package]]
 name = "dothttp"
-version = "0.8.1"
+version = "0.8.0"
 dependencies = [
+ "ascii_table",
  "axum",
  "boa_engine",
  "boa_runtime",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -567,7 +567,7 @@ dependencies = [
 
 [[package]]
 name = "dothttp"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "ascii_table",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ rand = "0.8.5"
 chrono = "0.4.31"
 tokio = { version = "1", features = ["net", "macros"] }
 http = "1.0.0"
+ascii_table = "4.0.3"
 
 [dev-dependencies]
 axum = "0.7.4"

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -19,11 +19,11 @@ impl<'a> Executor<'a> {
     }
 
     fn request_name(&self) -> String {
-        if let Some(name) = &self.source.script.name {
-            format!("{} / {name}", self.source.name)
-        } else {
-            format!("{} / #{}", self.source.name, self.source.index + 1)
-        }
+        format!(
+            "{} / {}",
+            self.source.source_name(),
+            self.source.request_name()
+        )
     }
 
     fn process_variables(&self, engine: &mut impl ScriptEngine) -> Result<()> {
@@ -134,11 +134,11 @@ impl<'a> Executor<'a> {
         engine.report().context("failed to get test report")
     }
 
-    pub(crate) async fn execute(
+    pub(crate) async fn execute<O: Output + ?Sized>(
         &mut self,
         client: &impl HttpClient,
         engine: &mut impl ScriptEngine,
-        output: &mut impl Output,
+        output: &mut O,
     ) -> Result<(String, TestsReport)> {
         let name = self.request_name();
         self.process_variables(engine)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,12 @@
-use std::{borrow::BorrowMut, io::stdout, path::PathBuf};
+use std::{
+    io::{stderr, stdout},
+    path::PathBuf,
+};
 
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 use color_eyre::Result;
 use dothttp::{
-    output::{parse_format, print::FormattedOutput},
+    output::{parse_format, print::FormattedOutput, CiOutput, Output},
     source::FilesSourceProvider,
     ClientConfig, EnvironmentFileProvider, Runtime,
 };
@@ -25,7 +28,7 @@ struct Args {
 
     files: Vec<String>,
 
-    /// The format of the request output
+    /// The format of the request output. Only relevant if `-format=standard`.
     ///
     /// Possible values:
     ///
@@ -39,7 +42,7 @@ struct Args {
     #[arg(long, default_value = "%N\n%R\n\n")]
     request_format: String,
 
-    /// The format of the response output
+    /// The format of the response output. Only relevant if `-format=standard`.
     ///
     /// Possible values:
     ///
@@ -55,10 +58,25 @@ struct Args {
 
     #[arg(long = "accept-invalid-certs")]
     accept_invalid_cert: bool,
+
+    /// Which mode to use to print result. Possible values:
+    ///
+    /// * standard [default]
+    ///
+    /// * ci
+    #[arg(long = "format", default_value = "standard")]
+    format: FormatType,
+}
+
+#[derive(Debug, Default, Copy, Clone, ValueEnum)]
+enum FormatType {
+    #[default]
+    Standard,
+    Ci,
 }
 
 #[tokio::main(flavor = "current_thread")]
-async fn main() -> Result<()> {
+async fn main() -> Result<std::process::ExitCode> {
     color_eyre::install()?;
 
     let Args {
@@ -69,6 +87,7 @@ async fn main() -> Result<()> {
         accept_invalid_cert,
         request_format,
         response_format,
+        format: output,
     } = Args::parse();
 
     let env = environment.unwrap_or("dev".to_owned());
@@ -78,19 +97,32 @@ async fn main() -> Result<()> {
 
     let client_config = ClientConfig::new(!ignore_certificates);
 
-    let mut stdout = stdout();
-    let mut output = FormattedOutput::new(
-        stdout.borrow_mut(),
-        parse_format(&preprocess_format_strings(request_format))?,
-        parse_format(&preprocess_format_strings(response_format))?,
-    );
+    let mut output = get_output(output, request_format, response_format)?;
     let mut environment = EnvironmentFileProvider::open(&env, &env_file, &snapshot_file)?;
 
-    let mut runtime = Runtime::new(&mut environment, output.borrow_mut(), client_config).unwrap();
+    let mut runtime = Runtime::new(&mut environment, &mut output, client_config).unwrap();
 
     runtime
         .execute(FilesSourceProvider::from_list(&files)?)
-        .await
+        .await?;
+
+    Ok(output.exit_code())
+}
+
+fn get_output(
+    ty: FormatType,
+    request_format: String,
+    response_format: String,
+) -> Result<Box<dyn Output>> {
+    Ok(match ty {
+        FormatType::Standard => Box::new(FormattedOutput::new(
+            stdout(),
+            stderr(),
+            parse_format(&preprocess_format_strings(request_format))?,
+            parse_format(&preprocess_format_strings(response_format))?,
+        )),
+        FormatType::Ci => Box::new(CiOutput::default()),
+    })
 }
 
 fn preprocess_format_strings(format: String) -> String {

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,40 +30,28 @@ struct Args {
 
     /// The format of the request output. Only relevant if `-format=standard`.
     ///
-    /// Possible values:
-    ///
-    /// * %R - HTTP protocol
-    ///
-    /// * %N - Request Name
-    ///
-    /// * %B - Request Body
-    ///
-    /// * %H - Request Headers
+    /// [possible values:
+    /// %R - HTTP protocol,
+    /// %N - request Name,
+    /// %B - request Body,
+    /// %H - request Headers]
     #[arg(long, default_value = "%N\n%R\n\n")]
     request_format: String,
 
     /// The format of the response output. Only relevant if `-format=standard`.
     ///
-    /// Possible values:
-    ///
-    /// * %R - HTTP protocol
-    ///
-    /// * %T - Response unit tests
-    ///
-    /// * %B - Response Body
-    ///
-    /// * %H - Response Headers
+    /// [possible values:
+    /// %R - HTTP protocol,
+    /// %T - Response unit tests,
+    /// %B - Response Body,
+    /// %H - Response Headers]
     #[arg(long, default_value = "%R\n%H\n%B\n\n%T\n")]
     response_format: String,
 
     #[arg(long = "accept-invalid-certs")]
     accept_invalid_cert: bool,
 
-    /// Which mode to use to print result. Possible values:
-    ///
-    /// * standard [default]
-    ///
-    /// * ci
+    /// Which mode to use to print result.
     #[arg(long = "format", default_value = "standard")]
     format: FormatType,
 }

--- a/src/output/ci.rs
+++ b/src/output/ci.rs
@@ -24,20 +24,22 @@ impl Output for CiOutput {
 
     fn tests(&mut self, tests: Vec<(String, String, TestsReport)>) -> crate::Result<()> {
         let mut ascii_table = AsciiTable::default();
+        ascii_table.set_max_width(256);
         ascii_table
             .column(0)
             .set_header("File")
-            .set_align(Align::Center);
+            .set_align(Align::Left);
         ascii_table
             .column(1)
             .set_header("Request")
-            .set_align(Align::Center);
+            .set_align(Align::Left);
         ascii_table
             .column(2)
             .set_header("Test")
-            .set_align(Align::Center);
+            .set_align(Align::Left);
         ascii_table
             .column(3)
+            .set_max_width(6)
             .set_header("Result")
             .set_align(Align::Center);
 

--- a/src/output/ci.rs
+++ b/src/output/ci.rs
@@ -1,0 +1,81 @@
+use std::process::ExitCode;
+
+use ascii_table::{Align, AsciiTable};
+
+use crate::{
+    http::{Request, Response},
+    output::Output,
+    script_engine::report::TestsReport,
+};
+
+#[derive(Debug, Default)]
+pub struct CiOutput {
+    error: bool,
+}
+
+impl Output for CiOutput {
+    fn response(&mut self, _response: &Response, _tests: &TestsReport) -> crate::Result<()> {
+        Ok(())
+    }
+
+    fn request(&mut self, _request: &Request, _request_name: &str) -> crate::Result<()> {
+        Ok(())
+    }
+
+    fn tests(&mut self, tests: Vec<(String, String, TestsReport)>) -> crate::Result<()> {
+        let mut ascii_table = AsciiTable::default();
+        ascii_table
+            .column(0)
+            .set_header("File")
+            .set_align(Align::Center);
+        ascii_table
+            .column(1)
+            .set_header("Request")
+            .set_align(Align::Center);
+        ascii_table
+            .column(2)
+            .set_header("Test")
+            .set_align(Align::Center);
+        ascii_table
+            .column(3)
+            .set_header("Result")
+            .set_align(Align::Center);
+
+        let mut data = vec![];
+        let mut total_requests = 0;
+        let mut failed_requests = 0;
+        for (file, request, tests) in &tests {
+            total_requests += 1;
+            if tests.is_empty() {
+                data.push([file.as_str(), request.as_str(), "NO TESTS FOUND", ""]);
+            }
+            let mut request_failed = false;
+            for (test, result) in tests.all() {
+                self.error = self.error || result.is_error();
+                request_failed = request_failed || result.is_error();
+                let result = if result.is_error() {
+                    "FAILED"
+                } else {
+                    "PASSED"
+                };
+                data.push([file.as_str(), request.as_str(), test, result]);
+            }
+            if request_failed {
+                failed_requests += 1;
+            }
+        }
+
+        ascii_table.print(data);
+        println!("{total_requests} requests completed, {failed_requests} have failed tests");
+
+        Ok(())
+    }
+
+    fn exit_code(&mut self) -> ExitCode {
+        if self.error {
+            ExitCode::FAILURE
+        } else {
+            ExitCode::SUCCESS
+        }
+    }
+}

--- a/src/output/tests.rs
+++ b/src/output/tests.rs
@@ -68,7 +68,13 @@ fn test_format_request() {
     let empty_format = parse_format("").expect("valid format");
 
     let mut buffer = Vec::new();
-    let mut empty_output = FormattedOutput::new(&mut buffer, empty_format.clone(), empty_format);
+    let mut err_buffer = Vec::new();
+    let mut empty_output = FormattedOutput::new(
+        &mut buffer,
+        &mut err_buffer,
+        empty_format.clone(),
+        empty_format,
+    );
     empty_output
         .request(&request, "")
         .expect("print works correctly");
@@ -79,7 +85,13 @@ fn test_format_request() {
 
     let full_format = parse_format("%R\n%H\n%B\n").expect("valid format");
     let mut buffer = Vec::new();
-    let mut outputter = FormattedOutput::new(&mut buffer, full_format.clone(), full_format);
+    let mut err_buffer = Vec::new();
+    let mut outputter = FormattedOutput::new(
+        &mut buffer,
+        &mut err_buffer,
+        full_format.clone(),
+        full_format,
+    );
     outputter
         .request(&request, "")
         .expect("print works correctly");
@@ -105,8 +117,13 @@ Content-Type: text/json
 
     let first_line_headers = parse_format("%R\n%H\n").expect("valid format");
     let mut buffer = Vec::new();
-    let mut outputter =
-        FormattedOutput::new(&mut buffer, first_line_headers.clone(), first_line_headers);
+    let mut err_buffer = Vec::new();
+    let mut outputter = FormattedOutput::new(
+        &mut buffer,
+        &mut err_buffer,
+        first_line_headers.clone(),
+        first_line_headers,
+    );
     outputter
         .request(&request, "")
         .expect("print works correctly");
@@ -126,7 +143,13 @@ Content-Type: text/json
 
     let only_first_line = parse_format("%R\n").expect("valid format");
     let mut buffer = Vec::new();
-    let mut outputter = FormattedOutput::new(&mut buffer, only_first_line.clone(), only_first_line);
+    let mut err_buffer = Vec::new();
+    let mut outputter = FormattedOutput::new(
+        &mut buffer,
+        &mut err_buffer,
+        only_first_line.clone(),
+        only_first_line,
+    );
     outputter
         .request(&request, "")
         .expect("print works correctly");

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -15,10 +15,12 @@ use http::header::CONTENT_TYPE;
 use serde_json::json;
 use tokio::sync::mpsc::{channel, Receiver, Sender};
 
-pub fn formatter() -> FormattedOutput<DebugWriter> {
+pub fn formatter() -> FormattedOutput<DebugWriter, DebugWriter> {
     let writer = DebugWriter(String::new());
+    let writer_err = DebugWriter(String::new());
     FormattedOutput::new(
         writer,
+        writer_err,
         parse_format("%R\n").unwrap(),
         parse_format("%R\n%H\n%B\n%T\n").unwrap(),
     )

--- a/tests/multi.rs
+++ b/tests/multi.rs
@@ -17,7 +17,11 @@ async fn multi_post() {
         .execute(FileSourceProvider::new("tests/requests/multi.http", None).unwrap())
         .await;
 
-    assert!(result.is_ok(), "Failed test:\n{}", output.into_writer().0);
+    assert!(
+        result.is_ok(),
+        "Failed test:\n{}",
+        output.into_writers().1 .0
+    );
 
     assert_eq!(server.requests().await.len(), 3);
 

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -20,7 +20,7 @@ async fn test_simple_get() {
     assert!(
         result.is_ok(),
         "Failed test:\n{}\nerror: {:?}",
-        output.into_writers().1,
+        output.into_writers().1 .0,
         result.unwrap_err()
     );
 
@@ -43,7 +43,7 @@ async fn test_simple_post() {
     assert!(
         result.is_ok(),
         "Failed test:\n{}\nerror: {result:?}",
-        output.into_writers().1
+        output.into_writers().1 .0
     );
 
     assert_eq!(server.requests().await.len(), 1);

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -20,7 +20,7 @@ async fn test_simple_get() {
     assert!(
         result.is_ok(),
         "Failed test:\n{}\nerror: {:?}",
-        output.into_writer().0,
+        output.into_writers().1,
         result.unwrap_err()
     );
 
@@ -43,7 +43,7 @@ async fn test_simple_post() {
     assert!(
         result.is_ok(),
         "Failed test:\n{}\nerror: {result:?}",
-        output.into_writer().0
+        output.into_writers().1
     );
 
     assert_eq!(server.requests().await.len(), 1);


### PR DESCRIPTION
Add more output formats (ci). To specify output format type, use --format argument
```
      --format <FORMAT>
          Which mode to use to print result
          
          [default: standard]
          [possible values: standard, ci]
```

Example output of `--format=ci`:

```
❯ dothttp --format ci requests.http
┌───────────────┬────────────────────┬───────────────┬────────┐
│ File          │ Request            │ Test          │ Result │
├───────────────┼────────────────────┼───────────────┼────────┤
│ requests.http │ Request to get     │ mock error    │ FAILED │
│ requests.http │ Successful request │ mock error    │ PASSED │
│ requests.http │ #3                 │ another error │ FAILED │
│ requests.http │ #3                 │ mock error    │ FAILED │
└───────────────┴────────────────────┴───────────────┴────────┘
3 requests completed, 2 have failed tests

```

Closes #8 